### PR TITLE
Support error handler on php >= 8.0

### DIFF
--- a/src/XmlBase.php
+++ b/src/XmlBase.php
@@ -73,7 +73,7 @@ class XmlBase
         return $this->dom->saveXML();
     }
 
-    public function onValidateError($no, $string, $file, $line, $context)
+    public function onValidateError($no, $string, $file, $line, $context = null)
     {
         $this->validationErrors[] = $string;
     }


### PR DESCRIPTION
According to https://www.php.net/manual/en/function.set-error-handler.php

Regarding the fifth parameter:

>Warning
>This parameter has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0. If the function defines this parameter without a default, an error of "too few arguments" will be raised when it is called.

I just experienced this. So let's set a default yeah